### PR TITLE
[Compiler Error] fix build error on macOS platform

### DIFF
--- a/task03-quad/src/main.cpp
+++ b/task03-quad/src/main.cpp
@@ -40,7 +40,7 @@ int main() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 使用核心模式(无需向后兼容性)
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 如果使用的是Mac OS X系统，需加上这行
-    glfwWindowHint(GLFW_RESIZABLE, FALSE);						    // 不可改变窗口大小
+    glfwWindowHint(GLFW_RESIZABLE, false);						    // 不可改变窗口大小
 
     // 创建窗口(宽、高、窗口名称)
     auto window = glfwCreateWindow(screen_width, screen_height, "Quad", nullptr, nullptr);

--- a/task04-sphere/src/main.cpp
+++ b/task04-sphere/src/main.cpp
@@ -33,7 +33,7 @@ int main()
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 使用核心模式(无需向后兼容性)
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 如果使用的是Mac OS X系统，需加上这行
-	glfwWindowHint(GLFW_RESIZABLE, FALSE);						    // 不可改变窗口大小
+	glfwWindowHint(GLFW_RESIZABLE, false);						    // 不可改变窗口大小
 
 																	// 创建窗口(宽、高、窗口名称)
 	auto window = glfwCreateWindow(screen_width, screen_height, "Sphere", nullptr, nullptr);

--- a/task05-model/src/main.cpp
+++ b/task05-model/src/main.cpp
@@ -38,7 +38,7 @@ int main() {
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 使用核心模式(无需向后兼容性)
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 如果使用的是Mac OS X系统，需加上这行
-	glfwWindowHint(GLFW_RESIZABLE, FALSE);						    // 不可改变窗口大小
+	glfwWindowHint(GLFW_RESIZABLE, false);						    // 不可改变窗口大小
 
 																	// 创建窗口(宽、高、窗口名称)
 	auto window = glfwCreateWindow(screen_width, screen_height, "model", nullptr, nullptr);

--- a/task06-cube/src/main.cpp
+++ b/task06-cube/src/main.cpp
@@ -74,7 +74,7 @@ int main() {
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 使用核心模式(无需向后兼容性)
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 如果使用的是Mac OS X系统，需加上这行
-	glfwWindowHint(GLFW_RESIZABLE, FALSE);						    // 不可改变窗口大小
+	glfwWindowHint(GLFW_RESIZABLE, false);						    // 不可改变窗口大小
 
 																	// 创建窗口(宽、高、窗口名称)
 	auto window = glfwCreateWindow(screen_width, screen_height, "Cube", nullptr, nullptr);

--- a/task07-camera/src/main.cpp
+++ b/task07-camera/src/main.cpp
@@ -79,7 +79,7 @@ int main() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 使用核心模式(无需向后兼容性)
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 如果使用的是Mac OS X系统，需加上这行
-    glfwWindowHint(GLFW_RESIZABLE, FALSE);						    // 不可改变窗口大小
+    glfwWindowHint(GLFW_RESIZABLE, false);						    // 不可改变窗口大小
 
     // 创建窗口(宽、高、窗口名称)
     auto window = glfwCreateWindow(screen_width, screen_height, "Camera", nullptr, nullptr);

--- a/task11-shadow/src/main.cpp
+++ b/task11-shadow/src/main.cpp
@@ -53,7 +53,7 @@ int main() {
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 使用核心模式(无需向后兼容性)
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 如果使用的是Mac OS X系统，需加上这行
-	glfwWindowHint(GLFW_RESIZABLE, FALSE);						    // 不可改变窗口大小
+	glfwWindowHint(GLFW_RESIZABLE, false);						    // 不可改变窗口大小
 
 																	// 创建窗口(宽、高、窗口名称)
 	auto window = glfwCreateWindow(screen_width, screen_height, "shadow", nullptr, nullptr);


### PR DESCRIPTION
# Background

This PR fixes an error when building the program because `FALSE` is not a keyword in c plus plus and will cause an error when compiling

<img width="748" alt="Screen Shot 2022-01-14 at 20 44 24" src="https://user-images.githubusercontent.com/9049783/149517373-63244dcf-4941-4d21-a62b-c6c15d87aa8f.png">

My environment

<img width="754" alt="Screen Shot 2022-01-14 at 20 45 36" src="https://user-images.githubusercontent.com/9049783/149517478-59f0f40a-adff-4323-af3e-0eded42033f1.png">

# Test plan

1. Pass CI
2. manual check

```bash
cmake . && make
```

we could get the result

<img width="641" alt="Screen Shot 2022-01-14 at 20 43 27" src="https://user-images.githubusercontent.com/9049783/149517267-aabafe5d-2685-41cf-8bea-9a1479bc092a.png">

Then we try to run the built product

<img width="1318" alt="Screen Shot 2022-01-14 at 20 48 20" src="https://user-images.githubusercontent.com/9049783/149517810-138336a9-079e-460a-a126-807375ff7a25.png">


# Reviewers

@wanlin405 @theIK1 